### PR TITLE
Db, errors, buttons

### DIFF
--- a/sqlscripts/dbsetup.sql
+++ b/sqlscripts/dbsetup.sql
@@ -51,7 +51,7 @@ CREATE TABLE TMatch (
 	REFERENCES Team(id),
 
 	CONSTRAINT Match_League_Relation FOREIGN KEY (league_id) 
-	REFERENCES League(id)
+	REFERENCES League(id) ON DELETE CASCADE
 );
 
 CREATE TABLE Suspension (
@@ -64,7 +64,7 @@ CREATE TABLE Suspension (
 	CONSTRAINT Suspension_Match_Relation FOREIGN KEY (match_id) 
 	REFERENCES TMatch(id) ON DELETE CASCADE,
 	CONSTRAINT Suspension_Team_Relation FOREIGN KEY (team_id) 
-	REFERENCES Team(id) ON DELETE CASCADE
+	REFERENCES Team(id)
 );
 
 CREATE TABLE Goal (
@@ -77,9 +77,5 @@ CREATE TABLE Goal (
 	CONSTRAINT Goal_Match_Relation FOREIGN KEY (match_id)
 	REFERENCES TMatch(id) ON DELETE CASCADE,
 	CONSTRAINT Goal_Team_Relation FOREIGN KEY (team_id)
-	REFERENCES Team(id) ON DELETE CASCADE
+	REFERENCES Team(id)
 );
-
-
-
-

--- a/src/presentation/CreateTeam.java
+++ b/src/presentation/CreateTeam.java
@@ -10,8 +10,7 @@ import javafx.stage.Stage;
 import logic.LeagueImpl;
 import logic.TeamImpl;
 
-public class CreateTeam 
-{
+public class CreateTeam {
 	private Stage window = new Stage();
 	private Scene scene;
 	private TextField teamName = new TextField();
@@ -22,45 +21,43 @@ public class CreateTeam
 	private LeagueImpl leagueImpl = new LeagueImpl();
 	private Validation validation = new Validation();
 	private TeamImpl teamImpl = new TeamImpl();
-	
-	public CreateTeam()
-	{
+
+	public CreateTeam() {
 		showTeamCreate();
 		createTeamButtonFunctionality();
 	}
 
-	private void showTeamCreate()
-	{ 
+	private void showTeamCreate() {
 		leagueChoice.getItems().addAll(leagueImpl.getAllLeagues());
-		
+
 		childLayout.childTop.getChildren().add(new Label("Opret hold"));
 		childLayout.childBottom.getChildren().addAll(confirmCreateBtn, cancelCreateBtn);
 		childLayout.childCenter.add(new Label("Hold navn"), 0, 0);
 		childLayout.childCenter.add(teamName, 1, 0);
 		childLayout.childCenter.add(new Label("Vælg liga"), 0, 1);
 		childLayout.childCenter.add(leagueChoice, 1, 1);
-		
 		scene = new Scene(childLayout.childRoot);
 		scene.getStylesheets().add(getClass().getResource("MyStyle.css").toExternalForm());
 		window.setScene(scene);
 		window.setTitle("Opret hold");
 		window.show();
 	}
-	
-	private void createTeamButtonFunctionality()
-	{
+
+	private void createTeamButtonFunctionality() {
 		confirmCreateBtn.setOnAction(e -> createConfirm());
 		cancelCreateBtn.setOnAction(e -> window.close());
 	}
-	
-	private void createConfirm()
-	{
-		if(validation.emptyStringWarning(teamName.getText()))
-			if(validation.confirmChanges())
-			{
-				teamImpl.createTeam(leagueChoice.getSelectionModel().getSelectedItem(), teamName.getText());
-				window.close();
-			}
+
+	private void createConfirm() {
+		League league = leagueChoice.getSelectionModel().getSelectedItem();
+		if (league != null)
+			if (validation.emptyStringWarning(teamName.getText()))
+				if (validation.confirmChanges()) {
+					teamImpl.createTeam(leagueChoice.getSelectionModel().getSelectedItem(), teamName.getText());
+					window.close();
+				}
+		else
+			validation.teamLeagueAlert();
 	}
-	
+
 }

--- a/src/presentation/LigaMenu.java
+++ b/src/presentation/LigaMenu.java
@@ -82,7 +82,12 @@ public class LigaMenu {
 		backBtn.setOnAction(e -> new Menu(stage));
 		updateTeamBtn.setOnAction(e -> new UpdateTeam());
 		createTeamBtn.setOnAction(e -> new CreateTeam());
-		refreshBtn.setOnAction(e -> loadTableView(leagueDropdown.getSelectionModel().getSelectedItem()));
+		refreshBtn.setOnAction(e -> {
+			if (leagueDropdown.getSelectionModel().getSelectedItem() == null)
+				validate.noLeagueChoosenAlert();
+			else
+				loadTableView(leagueDropdown.getSelectionModel().getSelectedItem());
+		});
 	}
 
 	private void leagueDropDown() {
@@ -162,9 +167,9 @@ public class LigaMenu {
 		TextField leagueNameField = new TextField();
 		leagueNameField.setPromptText("Liga navn");
 		layout.childCenter.add(leagueNameField, 1, 1);
-		Button addBtn = new Button("OK");
+		Button confirmBtn = new Button("OK");
 		Button cancelBtn = new Button("Annuller");
-		layout.childCenter.add(addBtn, 0, 2);
+		layout.childCenter.add(confirmBtn, 0, 2);
 		layout.childCenter.add(cancelBtn, 1, 2);
 		Scene scene = new Scene(layout.childRoot);
 		scene.getStylesheets().add(getClass().getResource("MyStyle.css").toExternalForm());
@@ -172,12 +177,18 @@ public class LigaMenu {
 		stage.setScene(scene);
 		stage.show();
 		leagues.setOnAction(e -> leagueNameField.setText(""));
-		addBtn.setOnAction(e -> {
-			if (validate.confirmChanges()) {
-				leagueImpl.updateLeague(leagues.getSelectionModel().getSelectedItem(), leagueNameField.getText());
-				stage.close();
-				leagueDropDown();
+		confirmBtn.setOnAction(e -> {
+			League league = leagues.getSelectionModel().getSelectedItem();
+			if (league != null) {
+				if (validate.emptyStringWarning(leagueNameField.getText()))
+					if (validate.confirmChanges()) {
+						leagueImpl.updateLeague(leagues.getSelectionModel().getSelectedItem(), leagueNameField.getText());
+						stage.close();
+						leagueDropDown();
+					}
 			}
+			else
+				validate.noLeagueChoosenAlert();
 		});
 		cancelBtn.setOnAction(e -> stage.close());
 	}

--- a/src/presentation/MatchMenu.java
+++ b/src/presentation/MatchMenu.java
@@ -26,6 +26,7 @@ public class MatchMenu {
 	private Layout layout = new Layout();
 	private ComboBox<League> leagueDropdown = new ComboBox<League>();
 	private TableView<Match> tableViewMatches = new TableView<Match>();
+	private Validation validate = new Validation();
 	
 	public MatchMenu(Stage stage) {
 		matchBtnFunctionality(stage);
@@ -67,7 +68,12 @@ public class MatchMenu {
 		backBtn.setOnAction(e -> new Menu(stage));
 		createMatchBtn.setOnAction(e-> new CreateMatch());
 		deleteMatchBtn.setOnAction(e -> new DeleteMatch());
-		refreshBtn.setOnAction(e -> loadTableView(leagueDropdown.getSelectionModel().getSelectedItem()));
+		refreshBtn.setOnAction(e -> {
+			if (leagueDropdown.getSelectionModel().getSelectedItem() == null)
+				validate.noLeagueChoosenAlert();
+			else
+				loadTableView(leagueDropdown.getSelectionModel().getSelectedItem());
+		});
 		importMatchBtn.setOnAction(e -> new ImportMatch());
 	}
 	

--- a/src/presentation/Validation.java
+++ b/src/presentation/Validation.java
@@ -49,5 +49,29 @@ public class Validation {
 		if (result.get() == confirmBtn)
 			alert.close();
 	}
+	
+	protected void teamLeagueAlert() {
+		Alert alert = new Alert(AlertType.ERROR);
+		alert.setTitle("Team ERROR");
+		alert.setHeaderText("Team hasn't been asigned a league.");
+		alert.setContentText("Du skal vælge hvilken liga holdet skal tilhøre.");
+		ButtonType confirmBtn = new ButtonType("OK", ButtonData.OK_DONE);
+		alert.getButtonTypes().setAll(confirmBtn);
+		Optional<ButtonType> result = alert.showAndWait();
+		if (result.get() == confirmBtn)
+			alert.close();
+	}
+	
+	protected void noLeagueChoosenAlert() {
+		Alert alert = new Alert(AlertType.ERROR);
+		alert.setTitle("League ERROR");
+		alert.setHeaderText("A league hasn't been choosen");
+		alert.setContentText("Du skal vælge en liga før du kan trykke 'Opdater'");
+		ButtonType confirmBtn = new ButtonType("OK", ButtonData.OK_DONE);
+		alert.getButtonTypes().setAll(confirmBtn);
+		Optional<ButtonType> result = alert.showAndWait();
+		if (result.get() == confirmBtn)
+			alert.close();
+	}
 
 }


### PR DESCRIPTION
- Cascade fejl mellem kamp og liga. "Man kunne ikke slette en kamp, på grund af fremmednøgler"
- Fejl opstod når man trykker på refresh, hvis man ikke har valgt en liga i dropdown. Fejlen opstod i både liga menuen og kamp menuen, og er fixet i begge.
- Man får ikke længere en fejl, hvis man prøver at oprette et hold uden at angive en liga.
- Man kan ikke længere opdaterer en liga uden at skrive et navn.